### PR TITLE
Update forecast data

### DIFF
--- a/services/api/src/hrrr_smoke/__init__.py
+++ b/services/api/src/hrrr_smoke/__init__.py
@@ -1,3 +1,4 @@
+from logging.config import dictConfig
 import os
 
 from flask import Flask
@@ -10,6 +11,28 @@ def cors(response):
 
 
 def create_app(config=None):
+    dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "default": {
+                    "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+                },
+            },
+            "handlers": {
+                "wsgi": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://flask.logging.wsgi_errors_stream",
+                    "formatter": "default",
+                }
+            },
+            "root": {
+                "level": "DEBUG",
+                "handlers": ["wsgi"],
+            },
+        }
+    )
+
     app = Flask(__name__)
 
     from . import routes

--- a/services/api/src/hrrr_smoke/cli.py
+++ b/services/api/src/hrrr_smoke/cli.py
@@ -58,7 +58,11 @@ def convert(skip_old_forecasts, grib_paths, zarr_path):
     for group_name, grib_path in grib_queue.items():
         _, filename = os.path.split(grib_path)
 
-        if z_array and z_array[group_name].attrs["source_filename"] >= filename:
+        group_exists = z_array and group_name in z_array
+        if group_exists and z_array[group_name].attrs["source_filename"] >= filename:
+            current_app.logger.debug(
+                f"Forecast for {group_name} exists, skipping {filename}"
+            )
             continue
 
         current_app.logger.info(f"Parsing {grib_path}")

--- a/services/api/src/hrrr_smoke/cli.py
+++ b/services/api/src/hrrr_smoke/cli.py
@@ -19,15 +19,19 @@ def cli():
 
 
 @cli.command()
-@click.option("--skip-old-forecasts/--no-skip-old-forecasts", default=True)
+@click.option(
+    "--skip-old-forecasts/--no-skip-old-forecasts",
+    default=True,
+    help="Skip forecasts for any time in the past (default: skip)",
+)
 @click.argument(
     "grib_paths",
     nargs=-1,
     type=click.Path(exists=True, readable=True, dir_okay=False, resolve_path=True),
 )
 @click.argument("zarr_path", type=click.Path(resolve_path=True))
-def convert(skip_old_forecasts, grib_paths, zarr_path):
-    """Convert a GRIB2 file into a compressed Zarr array"""
+def update(skip_old_forecasts, grib_paths, zarr_path):
+    """Update a Zarr array with new forecasts from GRIB files"""
 
     grib_queue = {}
     now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
@@ -81,9 +85,17 @@ def convert(skip_old_forecasts, grib_paths, zarr_path):
 
 
 @cli.command()
-@click.option("-k", "--keep", type=int, default=6)
+@click.option(
+    "--keep",
+    "-k",
+    type=int,
+    default=6,
+    help="How many hours into the past to keep forecasts (default: 6)",
+)
 @click.argument("zarr_path", type=click.Path(resolve_path=True))
 def clean(keep, zarr_path):
+    """Remove old forecasts from the Zarr array"""
+
     if not os.path.exists(zarr_path):
         current_app.logger.info(f"{zarr_path} does not exist, exiting")
         return 0

--- a/services/api/src/hrrr_smoke/hrrr.py
+++ b/services/api/src/hrrr_smoke/hrrr.py
@@ -1,5 +1,7 @@
 """Utilities for working with HRRR output"""
 
+from datetime import datetime, timedelta
+
 import cartopy.crs as ccrs
 import numpy as np
 import xarray as xr
@@ -9,6 +11,21 @@ __all__ = ["read_grib"]
 
 
 EARTH_EQUATORIAL_RADIUS_M = 6371229.0
+
+
+ForecastDate = namedtuple("ForecastDate", ["analysis_date", "valid_date"])
+
+
+def parse_grib_filename(filename):
+    """Return the analysis and valid dates encoded in GRIB2 filenames."""
+
+    analysis_date = filename[:-2]
+    forecast_hour = filename[-2:]
+
+    analysis_date = datetime.strptime("%y%j%H%M%S")
+    valid_date = analysis_date + timedelta(hours=forecast_hour)
+
+    return ForecastDate(analysis_date, valid_date)
 
 
 def grid(grib_msg):

--- a/services/api/src/hrrr_smoke/hrrr.py
+++ b/services/api/src/hrrr_smoke/hrrr.py
@@ -1,5 +1,6 @@
 """Utilities for working with HRRR output"""
 
+from collections import namedtuple
 from datetime import datetime, timedelta
 
 import cartopy.crs as ccrs
@@ -20,9 +21,9 @@ def parse_grib_filename(filename):
     """Return the analysis and valid dates encoded in GRIB2 filenames."""
 
     analysis_date = filename[:-2]
-    forecast_hour = filename[-2:]
+    forecast_hour = int(filename[-2:])
 
-    analysis_date = datetime.strptime("%y%j%H%M%S")
+    analysis_date = datetime.strptime(analysis_date, "%y%j%H%M%S")
     valid_date = analysis_date + timedelta(hours=forecast_hour)
 
     return ForecastDate(analysis_date, valid_date)


### PR DESCRIPTION
Modify the CLI for the API to update an existing Zarr array with new forecast information and clean up old forecasts (to save on disk space).

Closes #33