### PR TITLE
Fix chart resizing

### DIFF
--- a/services/frontend/src/App.svelte
+++ b/services/frontend/src/App.svelte
@@ -92,15 +92,12 @@
 
 <Header />
 <HrrrControls {start} {end} />
-<div class="main">
-  <!--
+<div class="main stack">
   {#if $path}
     <XSection mapData={verticallyIntegratedSmoke} />
   {:else}
     <HrrrMap data={verticallyIntegratedSmoke} />
   {/if}
-  -->
-  <HrrrMap data={verticallyIntegratedSmoke} />
 </div>
 <Legend title="Smoke Concentration ({units})" />
 <Footer />

--- a/services/frontend/src/App.svelte
+++ b/services/frontend/src/App.svelte
@@ -8,9 +8,6 @@
   import Legend from "./components/Legend.svelte";
   import XSection from "./components/XSection.svelte";
 
-  let mapWidth = 0;
-  let mapHeight = 0;
-
   $: start = {
     lat: $path?.startLat,
     lng: $path?.startLng,
@@ -95,12 +92,15 @@
 
 <Header />
 <HrrrControls {start} {end} />
-{#if $path}
-  <XSection mapData={verticallyIntegratedSmoke} />
-{:else}
-  <div class="main" bind:offsetWidth={mapWidth} bind:offsetHeight={mapHeight}>
-    <HrrrMap width={mapWidth} height={mapHeight} data={verticallyIntegratedSmoke} />
-  </div>
-{/if}
-  <Legend title="Smoke Concentration ({units})" />
+<div class="main">
+  <!--
+  {#if $path}
+    <XSection mapData={verticallyIntegratedSmoke} />
+  {:else}
+    <HrrrMap data={verticallyIntegratedSmoke} />
+  {/if}
+  -->
+  <HrrrMap data={verticallyIntegratedSmoke} />
+</div>
+<Legend title="Smoke Concentration ({units})" />
 <Footer />

--- a/services/frontend/src/api.js
+++ b/services/frontend/src/api.js
@@ -2,6 +2,11 @@
 // fetching cross-sections.
 const HRRR_XSECTION_API = __HRRR_XSECTION_API__;
 
+export function borders() {
+  return fetch('/data/us.json')
+    .then((response) => response.json());
+}
+
 export function forecasts() {
   return fetch(`${HRRR_XSECTION_API}/forecasts/`)
     .then((response) => response.json());

--- a/services/frontend/src/components/HrrrMap.svelte
+++ b/services/frontend/src/components/HrrrMap.svelte
@@ -13,8 +13,8 @@
   import { afterUpdate, onMount } from "svelte";
 
   export let data;
-  export let width = 0;
-  export let height = 0;
+  let width = 0;
+  let height = 0;
 
   let counties;
   let states;
@@ -197,12 +197,22 @@
   }
 </script>
 
-<Loading promise={data}>
-  <canvas
-    bind:this={canvas}
-    on:click={handleClick}
-    class="hrrr-map"
-    width={width}
-    height={height}
-  ></canvas>
-</Loading>
+<div class="container" bind:offsetWidth={width} bind:offsetHeight={height}>
+  <Loading promise={data}>
+    <canvas
+      bind:this={canvas}
+      on:click={handleClick}
+      class="hrrr-map"
+      width={width}
+      height={height}
+    ></canvas>
+  </Loading>
+</div>
+
+<style>
+  .container {
+    aspect-ratio: 1/1;
+    width: 100%;
+    overflow: hidden;
+  }
+</style>

--- a/services/frontend/src/components/HrrrMap.svelte
+++ b/services/frontend/src/components/HrrrMap.svelte
@@ -87,11 +87,8 @@
   function draw() {
     if (!(canvas && projection)) return;
 
-    console.log(`redraw map ${width}×${height}`);
     const context = canvas.getContext("2d");
 
-    console.log('clearing map');
-    console.log(context);
     context.clearRect(0, 0, width, height);
 
     const p = geoPath(projection, context);
@@ -99,7 +96,6 @@
     const style = getComputedStyle(canvas);
 
     if (counties) {
-      console.log("drawing counties");
       context.strokeStyle = style.getPropertyValue("--county-border-color");
       context.lineWidth = +style.getPropertyValue("--county-border-width");
 
@@ -109,7 +105,6 @@
     }
 
     if (states) {
-      console.log("drawing states");
       context.save();
       context.strokeStyle = style.getPropertyValue("--state-border-color");
       context.lineWidth = +style.getPropertyValue("--state-border-width");
@@ -121,12 +116,6 @@
     }
 
     if (smoke) {
-      console.assert(columns > 0, 'columns must be > 0');
-      console.assert(rows > 0, 'rows must be > 0');
-      console.assert(longitude.length > 0, 'longitude.length must be > 0');
-      console.assert(latitude.length > 0, 'latitude.length must be > 0');
-      console.log("drawing smoke");
-
       const smokePath = geoPath(geoTransform({
         point: function (x, y) {
           const i = Math.max(0, Math.min(columns, Math.floor(x)));
@@ -157,10 +146,6 @@
     }
 
     if (xsectionPath) {
-      console.assert(width > 0, 'width should be positive');
-      console.assert(height > 0, 'height should be positive');
-      console.log("drawing path");
-
       const degPerPx = Math.max(
         Math.abs($path.startLng - $path.endLng) / width,
         Math.abs($path.startLat - $path.endLat) / height
@@ -181,8 +166,6 @@
         p,
       );
     }
-
-    console.log("redraw complete");
   }
 
   function handleClick(event) {

--- a/services/frontend/src/components/HrrrMap.svelte
+++ b/services/frontend/src/components/HrrrMap.svelte
@@ -1,5 +1,6 @@
 <script>
   import {
+    borders,
     path,
     smokeScale,
     thresholds,
@@ -9,15 +10,12 @@
   import { extent } from "d3-array";
   import { contours } from "d3-contour";
   import { geoPath, geoAlbers, geoCircle, geoStream, geoTransform } from "d3-geo";
-  import { mesh } from "topojson-client";
-  import { afterUpdate, onMount } from "svelte";
+  import { afterUpdate } from "svelte";
 
   export let data;
   let width = 0;
   let height = 0;
 
-  let counties;
-  let states;
   let canvas;
   let smoke;
   let columns = 0;
@@ -25,6 +23,9 @@
   let latitude;
   let longitude;
   let startPoint = null;
+
+  $: counties = $borders?.counties;
+  $: states = $borders?.states;
 
   $: data.then(function (data) {
     if (data === null) return;
@@ -64,15 +65,6 @@
   }
 
   afterUpdate(draw);
-
-  onMount(() => {
-    fetch("/data/us.json")
-      .then((res) => res.json())
-      .then((geodata) => {
-        counties = mesh(geodata, geodata.objects.counties);
-        states = mesh(geodata, geodata.objects.states);
-      });
-  });
 
   function drawPath(context, color, width, radius, p) {
     const c = geoCircle().radius(radius);

--- a/services/frontend/src/components/HrrrMap.svelte
+++ b/services/frontend/src/components/HrrrMap.svelte
@@ -7,7 +7,6 @@
   } from "../stores.js";
   import Loading from "./Loading.svelte";
 
-  import { extent } from "d3-array";
   import { contours } from "d3-contour";
   import { geoPath, geoAlbers, geoCircle, geoStream, geoTransform } from "d3-geo";
   import { afterUpdate } from "svelte";

--- a/services/frontend/src/components/Legend.svelte
+++ b/services/frontend/src/components/Legend.svelte
@@ -51,7 +51,12 @@
     padding: 0;
     display: grid;
     grid-template-columns: min-content min-content;
+    grid-template-rows: 100%;
     grid-template-areas: "axis title";
+
+    height: 100%;
+    overflow: hidden;
+    padding-block: 0.5rem;
   }
 
   .axis {

--- a/services/frontend/src/components/Loading.svelte
+++ b/services/frontend/src/components/Loading.svelte
@@ -1,6 +1,6 @@
 <script>
   export let promise;
-  export let classNames;
+  export let classNames = "";
 </script>
 
 <div class="container stack {classNames}">

--- a/services/frontend/src/components/Loading.svelte
+++ b/services/frontend/src/components/Loading.svelte
@@ -3,7 +3,7 @@
   export let classNames;
 </script>
 
-<div class="stack {classNames}">
+<div class="container stack {classNames}">
   <slot></slot>
   {#await promise}
     <div class="spinner stack">
@@ -13,6 +13,12 @@
 </div>
 
 <style>
+.container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 .spinner > * {
   place-self: center;
   z-index: 1;

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -25,7 +25,6 @@
 
   let width = 0;
   let height = 0;
-  let mapSize = 0;
 
   let columns = 0;
   let rows = 0;
@@ -71,8 +70,8 @@
       </svg>
     </div>
 
-    <div class="map" bind:offsetWidth={mapSize}>
-      <HrrrMap width={mapSize} height={mapSize} data={mapData} />
+    <div class="map">
+      <HrrrMap data={mapData} />
     </div>
 
     <small class="axis-title left">Pressure (mb, from Standard Atmosphere)</small>

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -81,6 +81,12 @@
 </Loading>
 
 <style>
+  .wrapper {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+
   .container {
     display: grid;
     grid-template-columns: min-content 1fr min-content;
@@ -88,12 +94,19 @@
     grid-template-areas:
       "left-axis chart       right-axis"
       "......... bottom-axis ..........";
+
+    height: 100%;
+    overflow: hidden;
   }
 
   .chart,
   .map {
     grid-area: chart;
     overflow: hidden;
+  }
+
+  .chart {
+    height: 100%;
   }
 
   .map {

--- a/services/frontend/src/stores.js
+++ b/services/frontend/src/stores.js
@@ -2,7 +2,29 @@
 import { scaleThreshold } from "d3-scale";
 import { interpolateOrRd } from "d3-scale-chromatic";
 import { derived, readable, writable } from "svelte/store";
+import { mesh } from "topojson-client";
 import * as api from "./api.js";
+
+let _borders;
+
+/**
+ * US state and county borders as GeoJSON.
+ */
+export const borders = readable(null, function (set) {
+  if (_borders) {
+    set(_borders);
+    return;
+  }
+
+  api.borders().then(function (borders) {
+    _borders = {
+      counties: mesh(borders, borders.objects.counties),
+      states: mesh(borders, borders.objects.states),
+    };
+
+    set(_borders);
+  });
+});
 
 /**
  * Forecast initialization time in ISO 8601 format.

--- a/services/frontend/src/styles/base/_global.scss
+++ b/services/frontend/src/styles/base/_global.scss
@@ -115,12 +115,18 @@ legend {
 
 @media screen and (min-height: #{uswds.units("tablet")}) and (min-aspect-ratio: 4/3) {
   body {
-    grid-template-columns: 2fr min-content minmax(auto, #{uswds.units("mobile-lg")});
+    grid-template-columns: 1fr min-content #{uswds.units("mobile-lg")};
     grid-template-rows: min-content 1fr min-content;
     grid-template-areas:
       "main ...... header"
       "main legend controls"
       "main ...... footer";
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .main {
+    height: 100%;
     overflow: hidden;
   }
 }

--- a/services/frontend/src/styles/base/_global.scss
+++ b/services/frontend/src/styles/base/_global.scss
@@ -87,7 +87,6 @@ legend {
   color: uswds.color("base-lightest");
 }
 
-.hrrr-xsection,
 .main {
   grid-area: main;
 }


### PR DESCRIPTION
Fix the sizing behavior of both the map and the cross-section chart so that they fit the screen correctly and don't grow infinitely when you resize the window.

Closes #51 and #16 