### PR TITLE
Clipped axis labels

### DIFF
--- a/hrrr-smoke-vis.code-workspace
+++ b/hrrr-smoke-vis.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/services/frontend/src/components/Axis.svelte
+++ b/services/frontend/src/components/Axis.svelte
@@ -4,6 +4,7 @@
   export let orientation = "bottom";
   export let tickLength = 8;
   export let tickPadding = 4;
+  export let format = (tick) => tick;
 
   $: isHorizontal = (["top", "bottom"].includes(orientation));
   $: tickEnd = (["top", "left"].includes(orientation))
@@ -27,10 +28,10 @@
     <g class="tick" transform="{tickTransform(tick)}">
       {#if isHorizontal}
         <line y2="{tickEnd}" />
-        <text y="{labelPos}" dominant-baseline={labelBaseline}>{tick}</text>
+        <text y="{labelPos}" dominant-baseline={labelBaseline}>{format(tick)}</text>
       {:else}
         <line x2="{tickEnd}" />
-        <text x="{labelPos}" text-anchor={labelAnchor}>{tick}</text>
+        <text x="{labelPos}" text-anchor={labelAnchor}>{format(tick)}</text>
       {/if}
     </g>
   {/each}

--- a/services/frontend/src/components/Axis.svelte
+++ b/services/frontend/src/components/Axis.svelte
@@ -12,6 +12,8 @@
   $: labelPos = (["top", "left"].includes(orientation))
     ? (tickLength + tickPadding) * -1
     : (tickLength + tickPadding);
+  $: labelAnchor = orientation === "left" ? "end" : "start";
+  $: labelBaseline = orientation === "bottom" ? "hanging" : "auto";
 
   function tickTransform(tick) {
     return isHorizontal
@@ -25,10 +27,10 @@
     <g class="tick" transform="{tickTransform(tick)}">
       {#if isHorizontal}
         <line y2="{tickEnd}" />
-        <text y="{labelPos}">{tick}</text>
+        <text y="{labelPos}" dominant-baseline={labelBaseline}>{tick}</text>
       {:else}
         <line x2="{tickEnd}" />
-        <text x="{labelPos}">{tick}</text>
+        <text x="{labelPos}" text-anchor={labelAnchor}>{tick}</text>
       {/if}
     </g>
   {/each}

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -31,6 +31,15 @@
   let xScale = scaleLinear();
   let yScale = scaleLinear();
   let contourPath;
+  let chartMargin = {
+    top: 24,
+    right: 24,
+    bottom: 32,
+    left: 32,
+  };
+
+  $: chartWidth = Math.max(width - chartMargin.left - chartMargin.right, 0);
+  $: chartHeight = Math.max(height - chartMargin.top - chartMargin.bottom, 0);
 
   $: ready = $runHour !== null && $validTime !== null && $path !== null;
   $: data = ready ? api.xsection({
@@ -48,8 +57,8 @@
   });
 
   $: smoke = contours().size([columns, rows]).thresholds($thresholds)(massden);
-  $: xScale = scaleLinear().domain([0, columns]).range([0, width]);
-  $: yScale = scaleLinear().domain([0, rows]).range([height, 0]);
+  $: xScale = scaleLinear().domain([0, columns]).range([0, chartWidth]);
+  $: yScale = scaleLinear().domain([0, rows]).range([chartHeight, 0]);
   $: contourPath = geoPath(geoTransform({
     point: function (x, y) {
       this.stream.point(xScale(x), yScale(y));
@@ -61,9 +70,11 @@
   <div class="container">
     <div class="chart" bind:offsetWidth={width} bind:offsetHeight={height}>
       <svg class="x-section" viewBox="0 0 {width} {height}">
-        <Contour contours={smoke} fill={$smokeScale} path={contourPath} />
-        <Axis orientation="right" scale={yScale} />
-        <Axis orientation="top" scale={xScale} transform="translate(0, {height})" />
+        <g transform="translate({chartMargin.left}, {chartMargin.top})">
+          <Contour contours={smoke} fill={$smokeScale} path={contourPath} />
+        </g>
+        <Axis orientation="left" scale={yScale} transform="translate({chartMargin.left}, {chartMargin.top})" />
+        <Axis orientation="bottom" scale={xScale} transform="translate({chartMargin.left}, {chartHeight + chartMargin.top})" />
       </svg>
     </div>
 

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -27,6 +27,7 @@
 
   let columns = 0;
   let rows = 0;
+  let distance = 0;
   let massden = [];
   let xScale = scaleLinear();
   let yScale = scaleLinear();
@@ -53,12 +54,17 @@
 
     columns = xsection.columns;
     rows = xsection.rows;
+
+    // Convert distnace from meters to kilometers
+    distance = xsection.distance / 1000;
+
     massden = xsection.massden;
   });
 
   $: smoke = contours().size([columns, rows]).thresholds($thresholds)(massden);
   $: xScale = scaleLinear().domain([0, columns]).range([0, chartWidth]);
   $: yScale = scaleLinear().domain([0, rows]).range([chartHeight, 0]);
+  $: distanceScale = scaleLinear().domain([0, distance]).range([0, chartWidth]);
   $: contourPath = geoPath(geoTransform({
     point: function (x, y) {
       this.stream.point(xScale(x), yScale(y));
@@ -74,7 +80,7 @@
           <Contour contours={smoke} fill={$smokeScale} path={contourPath} />
         </g>
         <Axis orientation="left" scale={yScale} transform="translate({chartMargin.left}, {chartMargin.top})" />
-        <Axis orientation="bottom" scale={xScale} transform="translate({chartMargin.left}, {chartHeight + chartMargin.top})" />
+        <Axis orientation="bottom" scale={distanceScale} transform="translate({chartMargin.left}, {chartHeight + chartMargin.top})" />
       </svg>
     </div>
 

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -14,6 +14,7 @@
 
   import {
     contours,
+    format,
     geoPath,
     geoTransform,
     scaleLinear,
@@ -80,7 +81,8 @@
           <Contour contours={smoke} fill={$smokeScale} path={contourPath} />
         </g>
         <Axis orientation="left" scale={yScale} transform="translate({chartMargin.left}, {chartMargin.top})" />
-        <Axis orientation="bottom" scale={distanceScale} transform="translate({chartMargin.left}, {chartHeight + chartMargin.top})" />
+        <Axis orientation="bottom" scale={distanceScale} transform="translate({chartMargin.left}, {chartHeight + chartMargin.top})"
+              format={format(",d")} />
       </svg>
     </div>
 

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -14,6 +14,7 @@
 
   import {
     contours,
+    extent,
     format,
     geoPath,
     geoTransform,
@@ -29,6 +30,7 @@
   let columns = 0;
   let rows = 0;
   let distance = 0;
+  let isobaricPressure = [];
   let massden = [];
   let xScale = scaleLinear();
   let yScale = scaleLinear();
@@ -37,7 +39,7 @@
     top: 24,
     right: 24,
     bottom: 32,
-    left: 32,
+    left: 64,
   };
 
   $: chartWidth = Math.max(width - chartMargin.left - chartMargin.right, 0);
@@ -55,6 +57,7 @@
 
     columns = xsection.columns;
     rows = xsection.rows;
+    isobaricPressure = xsection.isobaricPressure;
 
     // Convert distnace from meters to kilometers
     distance = xsection.distance / 1000;
@@ -66,6 +69,7 @@
   $: xScale = scaleLinear().domain([0, columns]).range([0, chartWidth]);
   $: yScale = scaleLinear().domain([0, rows]).range([chartHeight, 0]);
   $: distanceScale = scaleLinear().domain([0, distance]).range([0, chartWidth]);
+  $: pressureScale = scaleLinear().domain(extent(isobaricPressure)).range([chartHeight, 0]);
   $: contourPath = geoPath(geoTransform({
     point: function (x, y) {
       this.stream.point(xScale(x), yScale(y));
@@ -80,7 +84,7 @@
         <g transform="translate({chartMargin.left}, {chartMargin.top})">
           <Contour contours={smoke} fill={$smokeScale} path={contourPath} />
         </g>
-        <Axis orientation="left" scale={yScale} transform="translate({chartMargin.left}, {chartMargin.top})" />
+        <Axis orientation="left" scale={pressureScale} transform="translate({chartMargin.left}, {chartMargin.top})" />
         <Axis orientation="bottom" scale={distanceScale} transform="translate({chartMargin.left}, {chartHeight + chartMargin.top})"
               format={format(",d")} />
       </svg>

--- a/services/frontend/src/components/XSection.svelte
+++ b/services/frontend/src/components/XSection.svelte
@@ -77,12 +77,6 @@
 </Loading>
 
 <style>
-  .wrapper {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-  }
-
   .container {
     display: grid;
     grid-template-columns: min-content 1fr min-content;


### PR DESCRIPTION
Adjust axis placement in the cross-section chart to eliminate clipping of axes. Label the x-axis with distances instead of columns in the cross-section grid, to ensure that even long numbers aren’t truncated.

Closes #65 
Closes #71 