### PR TITLE
Change the smoke concentration scale to 0–300

### DIFF
--- a/services/frontend/src/stores.js
+++ b/services/frontend/src/stores.js
@@ -43,7 +43,7 @@ export const validTime = writable(0);
  * @type {number[]}
  */
 export const thresholds = readable(
-  [0, 1, 4, 7, 11, 15, 20, 25, 30, 40, 50, 75, 150, 250, 500]
+  [0, 1, 2, 4, 6, 8, 12, 16, 20, 25, 30, 40, 100, 200]
 );
 
 /**


### PR DESCRIPTION
I was using the scale from vertically integrated smoke instead of the
cross-sections for my scale, which went up to 500 µg/m³, but the cross-
section charts only go up to 300 µg/m³. This makes a lot of the smoke
concentration more visible because we get up to those brighter values
sooner.
