### PR TITLE
Set the height of the main area on small screens

### DIFF
--- a/services/frontend/src/styles/_base.scss
+++ b/services/frontend/src/styles/_base.scss
@@ -24,7 +24,7 @@ body {
   display: grid;
   grid-auto-flow: row;
   grid-template-columns: 1fr min-content;
-  grid-template-rows: min-content min-content 1fr min-content;
+  grid-template-rows: min-content min-content min(100vw, 95vh) min-content;
   grid-template-areas:
     "header   header"
     "controls controls"


### PR DESCRIPTION
To prevent the cross-section chart from growing endlessly, I've set an
explicit height for the row on small screens.